### PR TITLE
Plugin download on client connection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,6 +198,7 @@ dependencies = [
  "rand",
  "serde",
  "wasmtime",
+ "xxhash-rust",
 ]
 
 [[package]]
@@ -1902,6 +1903,12 @@ dependencies = [
  "unicode-xid",
  "url",
 ]
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "735a71d46c4d68d71d4b24d03fdc2b98e38cea81730595801db779c04fe80d70"
 
 [[package]]
 name = "zstd"

--- a/cimvr.py
+++ b/cimvr.py
@@ -98,7 +98,7 @@ def main():
         cmds += [cmd]
 
     if args.client:
-        cmd = [client_exe] + plugins
+        cmd = [client_exe]
         if args.vr:
             cmd.append("--vr")
         if args.remote:

--- a/client/Cargo.lock
+++ b/client/Cargo.lock
@@ -220,6 +220,7 @@ dependencies = [
  "bytemuck",
  "cimvr_common",
  "cimvr_engine",
+ "directories",
  "egui 0.19.0 (git+https://github.com/Masterchef365/egui.git?branch=fix-glow-winit-dpi)",
  "egui-winit 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "egui_glow",
@@ -267,6 +268,7 @@ dependencies = [
  "rand",
  "serde",
  "wasmtime",
+ "xxhash-rust",
 ]
 
 [[package]]
@@ -647,6 +649,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
 name = "directories-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -654,6 +665,18 @@ checksum = "339ee130d97a610ea5a5872d2bbb130fdf68884ff09d3028b81bec8a1ac23bbc"
 dependencies = [
  "cfg-if",
  "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1810,6 +1833,12 @@ dependencies = [
  "jni",
  "libc",
 ]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "osmesa-sys"
@@ -3306,6 +3335,12 @@ name = "xml-rs"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "735a71d46c4d68d71d4b24d03fdc2b98e38cea81730595801db779c04fe80d70"
 
 [[package]]
 name = "zstd"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -29,6 +29,7 @@ egui_glow = { version = "0.19.0", features = ["winit"], git = "https://github.co
 egui-winit = { version = "0.19.0", default-features = false }
 raw-window-handle = "0.5.0"
 gilrs = { version = "0.10.2", default-features = false, features = ["xinput"] }
+directories = "5.0.1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 openxr = { version = "0.17.1", optional = true, features = ["loaded"] }

--- a/client/src/desktop.rs
+++ b/client/src/desktop.rs
@@ -33,7 +33,7 @@ pub fn mainloop(args: Opt) -> Result<()> {
     let mut input = DesktopInputHandler::new();
 
     // Setup client code
-    let mut client = Client::new(gl, &args.plugins, args.connect, args.username.unwrap())?;
+    let mut client = Client::new(gl, args.connect, args.username.unwrap())?;
 
     // Run event loop
     event_loop.run(move |event, _, control_flow| {

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -106,7 +106,6 @@ impl Client {
         loop {
             match recv_buf.read(&mut conn)? {
                 ReadState::Complete(data) => {
-                    dbg!(data.len());
                     response = deserialize(std::io::Cursor::new(data))?;
                     break;
                 }

--- a/client/src/plugin_cache.rs
+++ b/client/src/plugin_cache.rs
@@ -1,0 +1,86 @@
+use std::{
+    collections::HashMap,
+    fmt::Display,
+    path::{Path, PathBuf},
+    str::FromStr,
+};
+
+use anyhow::{format_err, Result};
+use cimvr_engine::{calculate_digest, interface::prelude::Digest};
+use directories::ProjectDirs;
+
+pub type Manifest = HashMap<Digest, PathBuf>;
+
+pub struct FileCache {
+    root: PathBuf,
+    manifest: Manifest,
+}
+
+impl FileCache {
+    /// Load the file cache (cheap)
+    pub fn new() -> Result<Self> {
+        let proj_dirs = ProjectDirs::from("com", "ChatImproVR", "ChatImproVR")
+            .ok_or(format_err!("Failed to determine cache dir"))?;
+        let root = proj_dirs.cache_dir().to_path_buf();
+
+        let manifest = read_manifest(&root)?;
+
+        Ok(Self { root, manifest })
+    }
+
+    /// Get the manifest describing all files in the cache
+    pub fn manifest(&self) -> &Manifest {
+        &self.manifest
+    }
+
+    /// Insert a file into the cache
+    pub fn add_file(&mut self, name: &str, data: &[u8]) -> Result<()> {
+        let digest = calculate_digest(data);
+        let cache_name = CacheName(digest, name.to_string());
+        let fname = cache_name.to_string();
+        let path = self.root.join(fname);
+        Ok(std::fs::write(path, data)?)
+    }
+}
+
+/// Read the file cache, parsing valid names into a manifest
+fn read_manifest(path: &Path) -> Result<Manifest> {
+    // Make sure directory exists
+    if !path.is_dir() {
+        std::fs::create_dir_all(path)?;
+    }
+
+    let mut manifest = HashMap::new();
+
+    for file in std::fs::read_dir(path)? {
+        let file = file?;
+        let path = file.path();
+        let Some(fname) = path.file_name() else { continue };
+        let fname = fname.to_str().ok_or(format_err!("Invalid cache name"))?;
+
+        if let Ok(name) = fname.parse() {
+            manifest.insert(name, path);
+        }
+    }
+
+    Ok(manifest)
+}
+
+struct CacheName(Digest, String);
+
+impl Display for CacheName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Self(digest, name) = self;
+        write!(f, "{digest}_{name}")
+    }
+}
+
+impl FromStr for CacheName {
+    type Err = anyhow::Error;
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        let (digest, name) = s
+            .split_once('_')
+            .ok_or(format_err!("No _ in cached file"))?;
+        Ok(Self(digest.parse()?, name.parse()?))
+    }
+}

--- a/client/src/plugin_cache.rs
+++ b/client/src/plugin_cache.rs
@@ -58,8 +58,8 @@ fn read_manifest(path: &Path) -> Result<Manifest> {
         let Some(fname) = path.file_name() else { continue };
         let fname = fname.to_str().ok_or(format_err!("Invalid cache name"))?;
 
-        if let Ok(name) = fname.parse() {
-            manifest.insert(name, path);
+        if let Ok(CacheName(digest, _)) = fname.parse() {
+            manifest.insert(digest, path);
         }
     }
 

--- a/client/src/vr.rs
+++ b/client/src/vr.rs
@@ -20,7 +20,7 @@ const VR_DEPTH_FORMAT: u32 = gl::DEPTH_COMPONENT24;
 
 pub fn mainloop(args: Opt) -> Result<()> {
     // Set up VR mainloop
-    let (mut main, event_loop) = MainLoop::new(args.plugins, args.connect, args.username.unwrap())?;
+    let (mut main, event_loop) = MainLoop::new(args.connect, args.username.unwrap())?;
 
     // Set up desktop input
     let mut input = DesktopInputHandler::new();
@@ -68,7 +68,6 @@ struct MainLoop {
 
 impl MainLoop {
     pub fn new(
-        plugins: Vec<PathBuf>,
         connect: SocketAddr,
         username: String,
     ) -> Result<(Self, EventLoop<()>)> {
@@ -142,7 +141,7 @@ impl MainLoop {
             glutin_openxr_opengl_helper::session_create_info(&glutin_ctx, &glutin_window)?;
 
         // Setup client code
-        let client = Client::new(gl.clone(), &plugins, connect, username)?;
+        let client = Client::new(gl.clone(), connect, username)?;
 
         // Create session
         let (xr_session, xr_frame_waiter, xr_frame_stream) =

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -14,3 +14,4 @@ rand = "0.8"
 ahash = "0.8.2"
 log = "0.4.17"
 notify = "5.0.0"
+xxhash-rust = { version = "0.8.5", features = ["xxh3"] }

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -3,6 +3,7 @@ pub mod hotload;
 pub mod network;
 pub mod plugin;
 pub mod timing;
+use cimvr_engine_interface::network::Digest;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, path::PathBuf};
 use timing::Timing;
@@ -47,8 +48,8 @@ pub struct Engine {
 
 /// Plugin management structure
 struct PluginState {
-    /// Path to this plugin's source code
-    path: PathBuf,
+    /// Unique name of this plugin
+    name: String,
     /// Plugin code and interface
     code: Plugin,
     /// Systems on this plugin
@@ -65,10 +66,10 @@ struct PluginState {
 pub struct PluginIndex(usize);
 
 impl PluginState {
-    pub fn new(path: PathBuf, wasm: &wasmtime::Engine) -> Result<Self> {
-        let code = Plugin::new(wasm, &path)?;
+    pub fn new(name: String, bytecode: &[u8], wasm: &wasmtime::Engine) -> Result<Self> {
+        let code = Plugin::new(wasm, bytecode)?;
         Ok(PluginState {
-            path,
+            name,
             code,
             outbox: vec![],
             systems: vec![],
@@ -76,23 +77,23 @@ impl PluginState {
         })
     }
 
-    pub fn name(&self) -> String {
-        self.path.file_name().unwrap().to_str().unwrap().to_string()
+    pub fn name(&self) -> &str {
+        &self.name
     }
 }
 
 impl Engine {
     /// Load plugins at the given paths
-    pub fn new(plugins: &[PathBuf], cfg: Config) -> Result<Self> {
+    pub fn new(plugins: &[(String, Vec<u8>)], cfg: Config) -> Result<Self> {
         let time = Timing::init();
 
         let wasm = wasmtime::Engine::new(&Default::default())?;
 
         let plugins: Vec<PluginState> = plugins
             .iter()
-            .map(|p| {
-                PluginState::new(p.clone(), &wasm)
-                    .with_context(|| format_err!("Initializing plugin {}", p.display()))
+            .map(|(name, bytecode)| {
+                PluginState::new(name.clone(), bytecode, &wasm)
+                    .with_context(|| format_err!("Initializing plugin {}", name))
             })
             .collect::<Result<_>>()?;
 
@@ -116,7 +117,7 @@ impl Engine {
     pub fn init_plugins(&mut self) -> Result<()> {
         // Dispatch all plugins
         for plugin_idx in 0..self.plugins.len() {
-            let name = self.plugins[plugin_idx].name();
+            let name = self.plugins[plugin_idx].name().to_string();
             self.init_plugin(plugin_idx)
                 .with_context(|| format_err!("Plugin {}", name))?;
         }
@@ -217,7 +218,7 @@ impl Engine {
             };
 
             // Run plugin
-            let name = plugin.name();
+            let name = plugin.name().to_string();
             let ret = plugin
                 .code
                 .dispatch(&recv_buf)
@@ -309,17 +310,16 @@ impl Engine {
     }
 
     /// Reload the plugin at the given path
-    pub fn reload(&mut self, path: PathBuf) -> Result<()> {
+    pub fn reload(&mut self, name: String, code: &[u8]) -> Result<()> {
         // Find old plugin
         let i = self
             .plugins
             .iter_mut()
-            .position(|p| p.path.canonicalize().unwrap() == path.canonicalize().unwrap())
+            .position(|p| p.name() == name)
             .expect("Requested plugin is not loaded");
 
         // Replace old plugin
-        let new_plugin = PluginState::new(path.clone(), &self.wasm)?;
-        let name = new_plugin.name();
+        let new_plugin = PluginState::new(name.clone(), code, &self.wasm)?;
 
         self.plugins[i] = new_plugin;
 
@@ -352,4 +352,9 @@ impl Engine {
         // Run PostInit stage
         self.dispatch_plugin(Stage::PostInit, i)
     }
+}
+
+/// Calculate the hash of a particular peice of data
+pub fn calculate_digest(data: &[u8]) -> Digest {
+    Digest(xxhash_rust::xxh3::xxh3_128(data))
 }

--- a/engine/src/network.rs
+++ b/engine/src/network.rs
@@ -13,6 +13,8 @@ pub struct ServerToClient {
     /// All ECS data with an associated `Synchronized` component attached
     pub ecs: EcsMap,
     pub messages: Vec<MessageData>,
+    /// Hotload the plugin with this name (String) using the given bytecode (Vec<u8>)
+    pub hotload: Vec<(String, Vec<u8>)>,
 }
 
 /// Message packet sent from client to server

--- a/engine/src/plugin.rs
+++ b/engine/src/plugin.rs
@@ -3,7 +3,7 @@ use cimvr_engine_interface::serial::{
     deserialize, serialize_into, serialized_size, ReceiveBuf, SendBuf,
 };
 use rand::prelude::*;
-use std::{io::Cursor, path::Path};
+use std::io::Cursor;
 use wasmtime::{Caller, Extern, Func, Instance, Memory, Module, Store, TypedFunc};
 
 #[allow(dead_code)]
@@ -20,9 +20,8 @@ pub struct Plugin {
 
 impl Plugin {
     /// Load the plugin in an uninitialized state
-    pub fn new(wt: &wasmtime::Engine, plugin_path: impl AsRef<Path>) -> Result<Self> {
-        let bytes = std::fs::read(plugin_path)?;
-        let module = Module::new(wt, &bytes)?;
+    pub fn new(wt: &wasmtime::Engine, code: &[u8]) -> Result<Self> {
+        let module = Module::new(wt, &code)?;
         let mut store = Store::new(wt, ());
 
         // Basic printing functionality

--- a/example_plugins/cube/src/lib.rs
+++ b/example_plugins/cube/src/lib.rs
@@ -61,7 +61,7 @@ fn cube() -> Mesh {
         Vertex::new([-size, -size, size], [1.0, 0.0, 1.0]),
         Vertex::new([size, -size, size], [1.0, 1.0, 0.0]),
         Vertex::new([size, size, size], [0.0, 1.0, 1.0]),
-        Vertex::new([-size, size, size], [1.0, 0.0, 1.0]),
+        Vertex::new([-size * 100., size, size], [1.0, 0.0, 1.0]),
     ];
 
     // Each 3 indices (indexing into vertices) define a triangle

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -195,6 +195,7 @@ impl Server {
             };
 
             // Write response
+            // TODO: Make this async - blocks whole server just to upload plugin data!
             if let Err(e) = length_delimit_message(&resp, &mut stream) {
                 log::error!("Client connection failed; {:#}", e);
             } else {

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -2,10 +2,11 @@ use anyhow::Result;
 
 use cimvr_engine::hotload::Hotloader;
 use cimvr_engine::interface::prelude::{
-    Access, ClientId, ConnectionRequest, Connections, Query, Synchronized,
+    Access, ClientId, ConnectionRequest, ConnectionResponse, Connections, Digest, PluginData,
+    Query, Synchronized,
 };
-use cimvr_engine::interface::serial::deserialize;
-use cimvr_engine::Config;
+use cimvr_engine::interface::serial::{deserialize, serialize_into};
+use cimvr_engine::{calculate_digest, Config};
 use cimvr_engine::{interface::system::Stage, network::*, Engine};
 
 use std::time::Instant;
@@ -16,7 +17,7 @@ use std::{
     time::Duration,
 };
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
@@ -44,14 +45,25 @@ fn main() -> Result<()> {
 
     // Set up engine and initialize plugins
     let hotload = Hotloader::new(&args.plugins)?;
-    let mut engine = Engine::new(&args.plugins, Config { is_server: true })?;
+
+    let plugins: Vec<(String, Vec<u8>)> = args
+        .plugins
+        .iter()
+        .map(|path| {
+            let name = path_to_plugin_name(&path);
+            let bytecode = std::fs::read(path)?;
+            Ok((name, bytecode))
+        })
+        .collect::<Result<_>>()?;
+
+    let mut engine = Engine::new(&plugins, Config { is_server: true })?;
     engine.init_plugins()?;
 
     // Create a new thread for the connection listener
     let (conn_tx, conn_rx) = mpsc::channel();
     std::thread::spawn(move || connection_listener(bind_addr, conn_tx));
 
-    let mut server = Server::new(conn_rx, engine, hotload);
+    let mut server = Server::new(conn_rx, engine, hotload, plugins);
     let target = Duration::from_millis(15);
 
     loop {
@@ -67,7 +79,10 @@ fn main() -> Result<()> {
 
 /// Thread which listens for new connections and sends them to the given MPSC channel
 /// Technically we could use a non-blocking connection accepter, but it was easier not to for now
-fn connection_listener(addr: SocketAddr, conn_tx: Sender<(TcpStream, String)>) -> Result<()> {
+fn connection_listener(
+    addr: SocketAddr,
+    conn_tx: Sender<(TcpStream, ConnectionRequest)>,
+) -> Result<()> {
     let listener = TcpListener::bind(addr)?;
     loop {
         let (mut stream, addr) = listener.accept()?;
@@ -76,7 +91,9 @@ fn connection_listener(addr: SocketAddr, conn_tx: Sender<(TcpStream, String)>) -
             continue;
         };
 
-        conn_tx.send((stream, req.username)).unwrap();
+        if req.validate() {
+            conn_tx.send((stream, req)).unwrap();
+        }
     }
 }
 
@@ -98,19 +115,32 @@ struct Connection {
 struct Server {
     /// ChatImproVR engine
     engine: Engine,
-    /// Incoming connections (Socket, Username)
-    conn_rx: Receiver<(TcpStream, String)>,
+    /// Incoming connections
+    conn_rx: Receiver<(TcpStream, ConnectionRequest)>,
     /// Existing connections
     conns: Vec<Connection>,
     /// Code hotloading
     hotload: Hotloader,
     /// Client ID increment
     id_counter: u32,
+    /// Currently loaded plugin bytecode. Can change during runtime,
+    /// so we keep this in order to send it to new clients
+    bytecode: Vec<(Digest, String, Vec<u8>)>,
 }
 
 impl Server {
-    fn new(conn_rx: Receiver<(TcpStream, String)>, engine: Engine, hotload: Hotloader) -> Self {
+    fn new(
+        conn_rx: Receiver<(TcpStream, ConnectionRequest)>,
+        engine: Engine,
+        hotload: Hotloader,
+        bytecode: Vec<(String, Vec<u8>)>,
+    ) -> Self {
+        let bytecode = bytecode
+            .into_iter()
+            .map(|(name, code)| (calculate_digest(&code), name, code))
+            .collect();
         Self {
+            bytecode,
             hotload,
             engine,
             conn_rx,
@@ -121,25 +151,63 @@ impl Server {
 
     fn update(&mut self) -> Result<()> {
         // Check for hotloaded plugins
+        let mut hotloaded = vec![];
         for path in self.hotload.hotload()? {
             log::info!("Reloading {}", path.display());
-            self.engine.reload(path)?;
+            let name = path_to_plugin_name(&path);
+            let bytecode = std::fs::read(path)?;
+            self.engine.reload(name.clone(), &bytecode)?;
+
+            // Update bytecode on our side so that newly connected clients will have the current code
+            *self
+                .bytecode
+                .iter_mut()
+                .find_map(|(_, plugin_name, code)| (plugin_name == &name).then(|| code))
+                .unwrap() = bytecode.clone();
+
+            // Remember which plugins were hotloaded, so that we can send code to
+            // the clients!
+            hotloaded.push((name, bytecode));
         }
 
         let mut conns_tmp = vec![];
 
         // Check for new connections
-        for (stream, username) in self.conn_rx.try_iter() {
+        for (mut stream, req) in self.conn_rx.try_iter() {
             stream.set_nonblocking(true)?;
             let addr = stream.peer_addr()?;
-            log::info!("{} Connected from {}", username, addr);
-            self.conns.push(Connection {
-                msg_buf: AsyncBufferedReceiver::new(),
-                stream,
-                username,
-                id: ClientId(self.id_counter),
-            });
-            self.id_counter += 1;
+
+            // Create connection on our side
+            log::info!("{} Connected from {}", req.username, addr);
+
+            // Send plugins to client
+            let mut response_plugins = vec![];
+            for (digest, name, code) in &self.bytecode {
+                // Only send plugin code that a given client does not already have!
+                if req.plugin_manifest.contains(&digest) {
+                    response_plugins.push((name.clone(), PluginData::Cached(*digest)));
+                } else {
+                    response_plugins.push((name.clone(), PluginData::Download(code.clone())));
+                }
+            }
+
+            let resp = ConnectionResponse {
+                plugins: response_plugins,
+            };
+
+            // Write response
+            if let Err(e) = serialize_into(&mut stream, &resp) {
+                log::error!("Client connection failed; {:#}", e);
+            } else {
+                // Remember connection on our side
+                self.conns.push(Connection {
+                    msg_buf: AsyncBufferedReceiver::new(),
+                    stream,
+                    username: req.username,
+                    id: ClientId(self.id_counter),
+                });
+                self.id_counter += 1;
+            }
         }
 
         // Read client messages
@@ -199,6 +267,7 @@ impl Server {
                 .ecs()
                 .export(&Query::new().intersect::<Synchronized>(Access::Read)),
             messages: self.engine.network_inbox(),
+            hotload: hotloaded,
         };
 
         // Write header and serialize message
@@ -226,4 +295,8 @@ impl Server {
 
         Ok(())
     }
+}
+
+fn path_to_plugin_name(path: &Path) -> String {
+    path.file_name().unwrap().to_str().unwrap().to_string()
 }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -159,11 +159,15 @@ impl Server {
             self.engine.reload(name.clone(), &bytecode)?;
 
             // Update bytecode on our side so that newly connected clients will have the current code
-            *self
+            let (entry_digest, entry_bytecode) = self
                 .bytecode
                 .iter_mut()
-                .find_map(|(_, plugin_name, code)| (plugin_name == &name).then(|| code))
-                .unwrap() = bytecode.clone();
+                .find_map(|(digest, plugin_name, code)| {
+                    (plugin_name == &name).then(|| (digest, code))
+                })
+                .unwrap();
+            *entry_digest = calculate_digest(&bytecode);
+            *entry_bytecode = bytecode.clone();
 
             // Remember which plugins were hotloaded, so that we can send code to
             // the clients!


### PR DESCRIPTION
This is a big one. The client now downloads plugins from the server during connection; the client does not need to be told which plugins are going to be in use because it will download them from the server. Because it would be very slow to send the plugins to clients each and every connection, clients now cache plugin code downloaded from the server for later re-use. **Hotloading has also been adapted to this; changes to plugin files server-side will be sent to clients!** This means you can still develop with the `cargo watch` workflow just like before. This means that ChatImproVR is now potentially a collaborative coding environment. 