### PR TITLE
Add compression to wasm sent over the wire!

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "ahash"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -194,6 +200,7 @@ dependencies = [
  "anyhow",
  "cimvr_engine_interface",
  "log",
+ "miniz_oxide",
  "notify",
  "rand",
  "serde",
@@ -911,6 +918,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+dependencies = [
+ "adler",
 ]
 
 [[package]]

--- a/client/Cargo.lock
+++ b/client/Cargo.lock
@@ -264,6 +264,7 @@ dependencies = [
  "anyhow",
  "cimvr_engine_interface",
  "log",
+ "miniz_oxide 0.7.1",
  "notify",
  "rand",
  "serde",

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -135,8 +135,9 @@ impl Client {
                 }
                 PluginData::Download(data) => {
                     log::info!("Downloaded {}, saving...", name);
-                    plugin_cache.add_file(&name, &data)?;
-                    bytecode = data;
+                    let decompressed = cimvr_engine::decompress(&data).context("Decompressing wasm")?;
+                    plugin_cache.add_file(&name, &decompressed)?;
+                    bytecode = decompressed;
                 }
             }
 
@@ -188,6 +189,7 @@ impl Client {
                     // Load hotloaded plugins
                     for (name, bytecode) in recv.hotload {
                         log::info!("Reloading {}", name);
+                        let bytecode = cimvr_engine::decompress(&bytecode).context("Decompressing wasm")?;
                         self.engine.reload(name, &bytecode)?;
                     }
 

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -15,3 +15,4 @@ ahash = "0.8.2"
 log = "0.4.17"
 notify = "5.0.0"
 xxhash-rust = { version = "0.8.5", features = ["xxh3"] }
+miniz_oxide = "0.7.1"

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -358,3 +358,13 @@ impl Engine {
 pub fn calculate_digest(data: &[u8]) -> Digest {
     Digest(xxhash_rust::xxh3::xxh3_128(data))
 }
+
+/// Compress some data
+pub fn compress(data: &[u8]) -> Vec<u8> {
+    miniz_oxide::deflate::compress_to_vec(data, 6)
+}
+
+/// Decompress some data
+pub fn decompress(data: &[u8]) -> Result<Vec<u8>> {
+    miniz_oxide::inflate::decompress_to_vec(data).map_err(|e| format_err!("{:#}", e))
+}

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -171,6 +171,7 @@ impl Server {
 
             // Remember which plugins were hotloaded, so that we can send code to
             // the clients!
+            let bytecode = cimvr_engine::compress(&bytecode);
             hotloaded.push((name, bytecode));
         }
 
@@ -190,7 +191,9 @@ impl Server {
                 if req.plugin_manifest.contains(&digest) {
                     response_plugins.push((name.clone(), PluginData::Cached(*digest)));
                 } else {
-                    response_plugins.push((name.clone(), PluginData::Download(code.clone())));
+                    // TODO: Do this only once!
+                    let bytecode = cimvr_engine::compress(&code);
+                    response_plugins.push((name.clone(), PluginData::Download(bytecode)));
                 }
             }
 


### PR DESCRIPTION
WASM files produced by RustC can be several megabytes. This should help loading times over slow connections!